### PR TITLE
fix: unable to use image sequence with mesh

### DIFF
--- a/packages/base/src/SpineBase.ts
+++ b/packages/base/src/SpineBase.ts
@@ -574,6 +574,9 @@ export abstract class SpineBase<
      * @private
      */
     createMesh(slot: ISlot, attachment: IMeshAttachment) {
+        if (!attachment.region && attachment.sequence) {
+            attachment.sequence.apply(slot, attachment as any);
+        }
         let region = attachment.region;
 
         if (slot.hackAttachment === attachment) {


### PR DESCRIPTION
This PR fixes this issues: 
https://github.com/pixijs/spine/issues/495
https://github.com/pixijs/spine/issues/530

After looking at what was happening with the slots, I found out that when the mesh was initially created, the attachment had no region, but it was installed during the first update. In this pull request, I made a small fix that did not affect the rest of the functionality, in the method for creating the mesh, I added a check if there was no region and there was a sequence field, I call the method that will install the region for the attachment

